### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/test-devops-2/985a6efd-536c-4706-b8ec-c4e61665d839/233e1459-486f-4377-acdd-355a144bf260/_apis/work/boardbadge/9ad0f479-4445-43e5-9bd7-ba7de01e027d)](https://dev.azure.com/test-devops-2/985a6efd-536c-4706-b8ec-c4e61665d839/_boards/board/t/233e1459-486f-4377-acdd-355a144bf260/Microsoft.RequirementCategory)
 # test-devops-eureka
 测试devops的eureka单节点服务
 master


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#28](https://dev.azure.com/test-devops-2/985a6efd-536c-4706-b8ec-c4e61665d839/_workitems/edit/28). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.